### PR TITLE
Feature + Fix

### DIFF
--- a/pidctrl.go
+++ b/pidctrl.go
@@ -102,6 +102,11 @@ func (c *PIDController) UpdateDuration(value float64, duration time.Duration) fl
 		d   float64
 	)
 	c.integral += err * dt * c.i
+	if c.integral > c.outMax {
+		c.integral = c.outMax
+	} else if c.integral < c.outMin {
+		c.integral = c.outMin
+	}
 	if dt > 0 {
 		d = -((value - c.prevValue) / dt)
 	}
@@ -109,10 +114,8 @@ func (c *PIDController) UpdateDuration(value float64, duration time.Duration) fl
 	output := (c.p * err) + c.integral + (c.d * d)
 
 	if output > c.outMax {
-		c.integral -= output - c.outMax
 		output = c.outMax
 	} else if output < c.outMin {
-		c.integral += c.outMin - output
 		output = c.outMin
 	}
 

--- a/pidctrl.go
+++ b/pidctrl.go
@@ -36,8 +36,9 @@ type PIDController struct {
 }
 
 // Set changes the setpoint of the controller.
-func (c *PIDController) Set(setpoint float64) {
+func (c *PIDController) Set(setpoint float64) *PIDController {
 	c.setpoint = setpoint
+	return c
 }
 
 // Get returns the setpoint of the controller.
@@ -46,10 +47,11 @@ func (c *PIDController) Get() float64 {
 }
 
 // SetPID changes the P, I, and D constants
-func (c *PIDController) SetPID(p, i, d float64) {
+func (c *PIDController) SetPID(p, i, d float64) *PIDController {
 	c.p = p
 	c.i = i
 	c.d = d
+	return c
 }
 
 // PID returns the P, I, and D constants
@@ -58,7 +60,7 @@ func (c *PIDController) PID() (p, i, d float64) {
 }
 
 // SetOutputLimits sets the min and max output values
-func (c *PIDController) SetOutputLimits(min, max float64) {
+func (c *PIDController) SetOutputLimits(min, max float64) *PIDController {
 	if min > max {
 		panic(MinMaxError{min, max})
 	}
@@ -70,6 +72,7 @@ func (c *PIDController) SetOutputLimits(min, max float64) {
 	} else if c.integral < c.outMin {
 		c.integral = c.outMin
 	}
+	return c
 }
 
 // OutputLimits returns the min and max output values


### PR DESCRIPTION
Hi,

While trying out your PIDctrl and comparing it with a version I wrote myself a few years back, I noticed that integral windup would still happen and affect the PID if the output just happened to keep within the min/max range.
Generated an example showing this, if you display the integral term values during the test, you will see what I mean.

Standard fix included.

Also a feature, where we can set OutputLimits in the same line as calling NewPIDController which is really useful if you want to put a ready to use PIDctrl into a struct.
